### PR TITLE
Remove the newline that accidentally got added in oauth2 proxy role

### DIFF
--- a/roles/oauth2-proxy/defaults/main.yml
+++ b/roles/oauth2-proxy/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 
 oauth2_proxy__version_long: 2.2.0.linux-amd64.go1.8.1
-oauth2_proxy__binary_sha256sum: >
+oauth2_proxy__binary_sha256sum: >-
   e8681643e3b562e479c76f471e79eb0225cdffa6b3f13d3ee175000cf0ce7d4d


### PR DESCRIPTION
Remove the newline that accidentally got added in 505ac8ffee9f24894e9fa1ef41a0c60c561a055e